### PR TITLE
fix(FEV-1598): when playlist position set to bottom/top the kitchen sink design doesn't match figma

### DIFF
--- a/src/components/playlist-item/playlist-item.scss
+++ b/src/components/playlist-item/playlist-item.scss
@@ -44,7 +44,6 @@ $playlist-item-metadata-height: 46px;
     padding: 0 6px 4px 6px;
     border-right: 2px solid transparent;
     align-items: flex-start;
-    max-width: min-content;
     .playlistItemThumbnailWrapper {
       margin-top: 1px;
       height: calc(100% - $playlist-item-metadata-height);
@@ -55,10 +54,12 @@ $playlist-item-metadata-height: 46px;
       height: $playlist-item-metadata-height;
       justify-content: flex-start;
       margin-top: 4px;
+      max-width: fit-content;
     .playlistItemTitle {
       margin-top: 4px;
       max-height: $line-height * 2;
       -webkit-line-clamp: 2;
+      word-break: break-word;
       &.hasDescription {
         max-height: $line-height;
         -webkit-line-clamp: 1;


### PR DESCRIPTION
**issue:**
when playlist is positioned top/bottom (horizontal layout), some items in the playlist are not responsive and the sizes of each item are not equals.

**solution:**
some css modifications.

Solves [FEV-1598](https://kaltura.atlassian.net/browse/FEV-1598)