### PR TITLE
fix(FEV-1298): seek player to 0 when selecting the active playlist item

### DIFF
--- a/src/components/playlist-wrapper/index.tsx
+++ b/src/components/playlist-wrapper/index.tsx
@@ -60,7 +60,7 @@ export const PlaylistWrapper = withText(translates)(
 
     const handlePlaylistItemClick = useCallback(
       (index: number) => () => {
-        playlist.playItem(index);
+        index === playlist.current.index ? player.currentTime = 0 : playlist.playItem(index);
       },
       [playlist]
     );


### PR DESCRIPTION
seek player to position 0 when selecting the active item (same entry which is already playing), instead of using playlist API which is using setMedia.

Solves [FEV-1298](https://kaltura.atlassian.net/browse/FEV-1298)