### PR TITLE
fix(FEV-1598): fix width of playlist items in horizontal layout

### DIFF
--- a/src/components/playlist-item/playlist-item.scss
+++ b/src/components/playlist-item/playlist-item.scss
@@ -44,6 +44,7 @@ $playlist-item-metadata-height: 46px;
     padding: 0 6px 4px 6px;
     border-right: 2px solid transparent;
     align-items: flex-start;
+    max-width: min-content;
     .playlistItemThumbnailWrapper {
       margin-top: 1px;
       height: calc(100% - $playlist-item-metadata-height);


### PR DESCRIPTION
handle the width of playlist items when in horizontal layout (top/bottom).

Solves [FEV-1598](https://kaltura.atlassian.net/browse/FEV-1598)

[FEV-1598]: https://kaltura.atlassian.net/browse/FEV-1598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ