### PR TITLE
fix(FEV-1598): fix width of the images in horizontal layout

### DIFF
--- a/src/components/playlist-item/playlist-item.scss
+++ b/src/components/playlist-item/playlist-item.scss
@@ -50,6 +50,9 @@ $playlist-item-metadata-height: 46px;
       height: calc(100% - $playlist-item-metadata-height);
       background-size: cover;
       max-height: 100%;
+      img {
+        max-width: fit-content; // override style from kms
+      }
     }
     .playlistItemMetadata {
       height: $playlist-item-metadata-height;


### PR DESCRIPTION
**the issue:**
in kms there is a style on img elements which breaks the design.

**solution:**
override the style.

Solves [FEV-1598](https://kaltura.atlassian.net/browse/FEV-1598)

[FEV-1598]: https://kaltura.atlassian.net/browse/FEV-1598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ