### PR TITLE
fix(SUP-39294): Page refreshes after clicking on player buttons

### DIFF
--- a/src/components/plugin-button/index.tsx
+++ b/src/components/plugin-button/index.tsx
@@ -22,6 +22,7 @@ export const PluginButton = withText(translates)(({isActive, setRef, ...otherPro
   return (
     <Tooltip label={otherProps.label} type="bottom">
       <button
+        type="button"
         data-testid={'playlist_pluginButton'}
         aria-label={otherProps.label}
         className={[ui.style.upperBarIcon, styles.pluginButton, isActive ? styles.active : ''].join(' ')}


### PR DESCRIPTION
**issue:**
When embed player in a form element and click on the plugin button, the page refreshes.

**solution:**
add type=button on the plugin button

solves [SUP-39294](https://kaltura.atlassian.net/browse/SUP-39294)

[SUP-39294]: https://kaltura.atlassian.net/browse/SUP-39294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ