### PR TITLE
fix(ADA-96): Playlist info at top of playlist not announced by JAWS

### DIFF
--- a/src/components/playlist-header/index.tsx
+++ b/src/components/playlist-header/index.tsx
@@ -35,11 +35,11 @@ export const PlaylistHeader = withText(translates)(
     const durationText = `${amount},${duration}`;
     return (
       <div className={[styles.playlistHeader, pluginMode === PluginPositions.VERTICAL ? styles.vertical : styles.horizontal].join(' ')}>
-        <div className={styles.playlistMetadata} tabIndex={0} ref={titleRef} aria-label={`${title} ${durationText}`}>
-          <div className={styles.playlistTitle} title={title} aria-hidden="true" data-testid={'playlist_title'}>
+        <div className={styles.playlistMetadata} tabIndex={0} ref={titleRef}>
+          <div className={styles.playlistTitle} title={title} data-testid={'playlist_title'}>
             {title}
           </div>
-          <div className={styles.playlistDuration} aria-hidden="true" data-testid={'playlist_duration'}>
+          <div className={styles.playlistDuration} data-testid={'playlist_duration'}>
             {durationText}
           </div>
         </div>


### PR DESCRIPTION
**issue:**
Title and description is not announced by JAWS since inner element are hidden.

**solution:**
remove aria-hidden and aria-label so the div content will be announced by the screen reader and not the aria-label

solves [ADA-96](https://kaltura.atlassian.net/browse/ADA-96)

[ADA-96]: https://kaltura.atlassian.net/browse/ADA-96?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ