### PR TITLE
fix(FEC-13517): Wrong and inconsistent order of plugins

### DIFF
--- a/src/components/plugin-button/index.tsx
+++ b/src/components/plugin-button/index.tsx
@@ -2,6 +2,7 @@ import {h} from 'preact';
 import {icons} from '../icons';
 import * as styles from './plugin-button.scss';
 import {ui} from '@playkit-js/kaltura-player-js';
+import { pluginName } from "../../index";
 
 const {Tooltip, Icon} = KalturaPlayer.ui.components;
 const {withText, Text} = KalturaPlayer.ui.preacti18n;
@@ -30,7 +31,7 @@ export const PluginButton = withText(translates)(({isActive, setRef, ...otherPro
           setRef(node);
         }}>
         <Icon
-          id="playlist-plugin-button"
+          id={pluginName}
           height={icons.BigSize}
           width={icons.BigSize}
           viewBox={`0 0 ${icons.BigSize} ${icons.BigSize}`}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,5 +11,5 @@ const NAME = __NAME__;
 export {Playlist as Plugin};
 export {VERSION, NAME};
 
-const pluginName: string = 'playlist';
+export const pluginName: string = 'playlist';
 KalturaPlayer.core.registerPlugin(pluginName, Playlist);

--- a/src/playlist.tsx
+++ b/src/playlist.tsx
@@ -7,6 +7,7 @@ import {PluginButton} from './components/plugin-button';
 import {PlaylistWrapper} from './components/playlist-wrapper';
 import {DataManager} from './data-manager';
 import {icons} from './components/icons';
+import { pluginName } from "./index";
 
 const {SidePanelModes, SidePanelPositions, ReservedPresetNames} = ui;
 
@@ -88,9 +89,14 @@ export class Playlist extends KalturaPlayer.core.BasePlugin {
     }) as number;
 
     // add plugin button
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     this._playlistIcon = this.upperBarManager!.add({
-      label: 'Playlist',
-      svgIcon: {path: icons.PLUGIN_ICON, viewBox: `0 0 ${icons.BigSize} ${icons.BigSize}`},
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      ariaLabel: 'Playlist',
+      displayName: 'Playlist',
+      svgIcon: {path: icons.PLUGIN_ICON},
       onClick: this._handleClickOnPluginIcon,
       component: () => {
         return <PluginButton isActive={this._isPluginActive()} setRef={this._setPluginButtonRef} />;


### PR DESCRIPTION
### Description of the Changes


**fix: Wrong and inconsistent order of plugins**

**fix: Plugins buttons sometimes display with the wrong icon**

**solves: [FEC-13517](https://kaltura.atlassian.net/browse/FEC-13517) [FEC-13517](https://kaltura.atlassian.net/browse/FEC-13517)**

[FEC-13517]: https://kaltura.atlassian.net/browse/FEC-13517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FEC-13517]: https://kaltura.atlassian.net/browse/FEC-13517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

#### Related Prs
https://github.com/kaltura/playkit-js-ui-managers/pull/51
https://github.com/kaltura/playkit-js-transcript/pull/175
https://github.com/kaltura/playkit-js-share/pull/38
https://github.com/kaltura/playkit-js-moderation/pull/74
https://github.com/kaltura/playkit-js-related/pull/61
https://github.com/kaltura/playkit-js-navigation/pull/348
https://github.com/kaltura/playkit-js-info/pull/90
https://github.com/kaltura/playkit-js-downloads/pull/39
https://github.com/kaltura/playkit-js-qna/pull/334