### PR TITLE
fix(FEC-13713): playlist is not updating the active item visually

### DIFF
--- a/src/components/playlist-wrapper/index.tsx
+++ b/src/components/playlist-wrapper/index.tsx
@@ -54,7 +54,7 @@ export const PlaylistWrapper = withText(translates)(
       playlistData.then(data => {
         setPlaylistExtraData(data);
       });
-      eventManager.listen(player, player.Event.MEDIA_LOADED, () => {
+      eventManager.listen(player, player.Event.CHANGE_SOURCE_ENDED, () => {
         setActiveIndex(playlist.current.index);
       });
     }, []);


### PR DESCRIPTION
- **bugfix**

**the issue:**
when loading a playlist where the player is in `autoplay=false` and switching between the items, the current active item is not being updated **visually** (marked with the blue line on the side).

**root cause:**
`setActiveItem` happens after `MEDIA_LOADED` event.
`MEDIA_LOADED` event is fired only after clicking play; so if choosing an item from the playlist panel and the player is still not starting to play, the active item indication (blue mark) is not being updated.

**solution:**
listen to `CHANGE_SOURCE_ENDED` event instead of `MEDIA_LOADED`.

Solves [FEC-13713](https://kaltura.atlassian.net/browse/FEC-13713)

[FEC-13713]: https://kaltura.atlassian.net/browse/FEC-13713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ