### PR TITLE
fix(ADA-10): Videos in playlist are not announced as an item that you can interact with such as a button or link using a screen reader

### DIFF
--- a/src/components/playlist-item/index.tsx
+++ b/src/components/playlist-item/index.tsx
@@ -157,7 +157,7 @@ export const PlaylistItem = withText(translates)(({item, active, onSelect, plugi
   }, [playlistItemName, pluginMode, playlistItemIndex, renderDescription]);
 
   return (
-    <A11yWrapper onClick={onSelect} role="listitem">
+    <A11yWrapper onClick={onSelect} role="button">
       <div
         title={`${otherProps.playlistItemIndex}${index + 1}. ${
           active ? otherProps.currentlyPlaying : otherProps.toPlayAreaLabel

--- a/src/components/playlist-wrapper/index.tsx
+++ b/src/components/playlist-wrapper/index.tsx
@@ -135,7 +135,6 @@ export const PlaylistWrapper = withText(translates)(
         <div
           className={[styles.playlistContent, scrolling ? styles.scrolling : ''].join(' ')}
           {...playlistContentParams}
-          role="list"
           aria-live="polite">
           {playlist.items.map((item: any) => {
             const {index} = item;


### PR DESCRIPTION
**Issue:**
Playlist items can't be navigation from button list in screen reader

**Solution:**
Change the role from "listitem" to "button"

Solved [ADA-10](https://kaltura.atlassian.net/browse/ADA-10)

[ADA-10]: https://kaltura.atlassian.net/browse/ADA-10?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ