### PR TITLE
fix(SUP-45650): [Oracle] Safari playlist vertical embed bottom side squeezed

### DIFF
--- a/src/components/playlist-item/playlist-item.scss
+++ b/src/components/playlist-item/playlist-item.scss
@@ -51,7 +51,7 @@ $playlist-item-metadata-height: 46px;
       background-size: cover;
       max-height: 100%;
       img {
-        max-width: fit-content; // override style from kms
+        max-width: initial; // override style from kms
       }
     }
     .playlistItemMetadata {


### PR DESCRIPTION
issue:
on safari browser playlist when choose side panel to be on the bottom, the list is squeezed and not the same as in chrome

solution:
change max width css as safari support fit-content different from chrome

solved [SUP-45650](https://kaltura.atlassian.net/browse/SUP-45650)

[SUP-45650]: https://kaltura.atlassian.net/browse/SUP-45650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ