### PR TITLE
fix(ADA-1736) - Tooltip strict position

### DIFF
--- a/src/components/plugin-button/index.tsx
+++ b/src/components/plugin-button/index.tsx
@@ -21,7 +21,7 @@ interface PluginButtonProps {
 
 export const PluginButton = withText(translates)(({isActive, setRef, ...otherProps}: PluginButtonProps) => {
   return (
-    <Tooltip label={otherProps.label} type="bottom">
+    <Tooltip label={otherProps.label} type="bottom-left" strictPosition={true}>
       <button
         type="button"
         data-testid={'playlist_pluginButton'}


### PR DESCRIPTION
This solves https://kaltura.atlassian.net/browse/ADA-1736. 
It sets the Tooltip position to always be bottom-left.