### PR TITLE
fix(SUP-48030): player V7 display issue on playlist with blocked and non-blocked content

### DIFF
--- a/src/playlist.tsx
+++ b/src/playlist.tsx
@@ -202,7 +202,7 @@ export class Playlist extends KalturaPlayer.core.BasePlugin {
 
   private _handleError = (e: any) => {
     if (e.payload.severity === core.Error.Severity.CRITICAL && this._player.playlist?.items?.length > 1) {
-      this.player.playlist.playNext();
+      this.player.playlist.playNext(true);
     }
   };
 


### PR DESCRIPTION
Issue:
When an entry that is part of a playlist got an error, it keeps the previous entry instead of the current entry to play.

Fix:
Add a case inside playNext, when a playlist that is part of the entry gets error.

solved [SUP-48030](https://kaltura.atlassian.net/browse/SUP-48030)

part of this PR's: https://github.com/kaltura/kaltura-player-js/pull/968/files
https://github.com/kaltura/playkit-js/pull/817

[SUP-48030]: https://kaltura.atlassian.net/browse/SUP-48030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ