### PR TITLE
feat(FEC-14489): Playlist language translation

### DIFF
--- a/src/components/playlist-item/index.tsx
+++ b/src/components/playlist-item/index.tsx
@@ -7,7 +7,7 @@ import {A11yWrapper} from '@playkit-js/common/dist/hoc/a11y-wrapper';
 import {icons} from '../icons';
 import {PluginPositions} from '../../types';
 import {KalturaViewHistoryUserEntry, KalturaBaseEntry, Capabilities} from '../../providers';
-import {KalturaMultiLingualData, MultiLingualData} from '../../providers/response-types/kaltura-multi-lingual-data';
+import {KalturaMultiLingualData, MultiLingualName} from '../../providers/response-types/kaltura-multi-lingual-data';
 
 const {withText, Text} = ui.preacti18n;
 const {Icon} = ui.components;
@@ -66,9 +66,9 @@ export const PlaylistItem = withPlayer(withText(translates)(({item, active, onSe
   const playlistItemName = useMemo(() => {
     // determine the title of the playlist item based on the multilingual data
     if (multiLingual) {
-      const { name } = multiLingual;
-      if (Array.isArray(name) && name.length > 0) {
-        const nameInLocale = name.find((name: MultiLingualData) => name.language.toLowerCase() === locale);
+      const { names } = multiLingual;
+      if (Array.isArray(names) && names.length > 0) {
+        const nameInLocale = names.find((mlName: MultiLingualName) => mlName.language.toLowerCase() === locale);
         if (nameInLocale) {
           return nameInLocale.value;
         }

--- a/src/components/playlist-item/index.tsx
+++ b/src/components/playlist-item/index.tsx
@@ -76,7 +76,7 @@ export const PlaylistItem = withPlayer(withText(translates)(({item, active, onSe
     }
     // fallback to the base entry name
     return sources.metadata?.name;
-  }, [baseEntry, locale]);
+  }, [multiLingual, locale]);
 
   const lastProgress = useMemo(() => {
     if (!viewHistory?.lastTimeReached) {

--- a/src/components/playlist-item/index.tsx
+++ b/src/components/playlist-item/index.tsx
@@ -7,6 +7,7 @@ import {A11yWrapper} from '@playkit-js/common/dist/hoc/a11y-wrapper';
 import {icons} from '../icons';
 import {PluginPositions} from '../../types';
 import {KalturaViewHistoryUserEntry, KalturaBaseEntry, Capabilities} from '../../providers';
+import {KalturaMultiLingualData, MultiLingualData} from '../../providers/response-types/kaltura-multi-lingual-data';
 
 const {withText, Text} = ui.preacti18n;
 const {Icon} = ui.components;
@@ -46,7 +47,9 @@ interface PlaylistItemProps {
   currentlyPlaying?: string;
   playlistItemIndex?: string;
   duration?: string;
-  player: any
+  player: any;
+  locale: string;
+  multiLingual?: KalturaMultiLingualData;
 }
 
 const MediaTypes = {
@@ -55,11 +58,25 @@ const MediaTypes = {
   Document: core.MediaType.DOCUMENT
 };
 
-export const PlaylistItem = withPlayer(withText(translates)(({item, active, onSelect, pluginMode, viewHistory, baseEntry, ...otherProps}: PlaylistItemProps) => {
+export const PlaylistItem = withPlayer(withText(translates)(({item, active, onSelect, pluginMode, viewHistory, baseEntry, multiLingual, locale, ...otherProps}: PlaylistItemProps) => {
   const {sources, index} = item;
   const playlistItemIndex = index + 1;
-  const playlistItemName = sources.metadata?.name;
   const duration = sources.duration || 0;
+
+  const playlistItemName = useMemo(() => {
+    // determine the title of the playlist item based on the multilingual data
+    if (multiLingual) {
+      const { name } = multiLingual;
+      if (Array.isArray(name) && name.length > 0) {
+        const nameInLocale = name.find((name: MultiLingualData) => name.language.toLowerCase() === locale);
+        if (nameInLocale) {
+          return nameInLocale.value;
+        }
+      }
+    }
+    // fallback to the base entry name
+    return sources.metadata?.name;
+  }, [baseEntry, locale]);
 
   const lastProgress = useMemo(() => {
     if (!viewHistory?.lastTimeReached) {

--- a/src/components/playlist-wrapper/index.tsx
+++ b/src/components/playlist-wrapper/index.tsx
@@ -138,6 +138,8 @@ export const PlaylistWrapper = withText(translates)(
                 pluginMode={pluginMode}
                 viewHistory={playlistExtraData?.viewHistory?.[item.sources.id]}
                 baseEntry={playlistExtraData?.baseEntry?.[item.sources.id]}
+                multiLingual={playlistExtraData?.multiLingual?.[item.sources.id]}
+                locale={player.config.ui.locale}
               />
             );
           })}

--- a/src/data-manager.ts
+++ b/src/data-manager.ts
@@ -1,6 +1,7 @@
 import {KalturaViewHistoryUserEntry, KalturaBaseEntry, PlaylistLoader} from './providers';
 import {PlaylistExtraData} from './types';
 import {KalturaPlayer} from '@playkit-js/kaltura-player-js'
+import {KalturaMultiLingualData} from './providers/response-types/kaltura-multi-lingual-data';
 
 export class DataManager {
   private _playlistData: PlaylistExtraData | null = null;
@@ -34,6 +35,7 @@ export class DataManager {
           const playlistLoader = data.get(PlaylistLoader.id);
           const viewHistory: Array<KalturaViewHistoryUserEntry> = playlistLoader?.response?.viewHistory;
           const baseEntry: Array<KalturaBaseEntry> = playlistLoader?.response?.baseEntry;
+          const multiLingual: Array<KalturaMultiLingualData> = playlistLoader?.response?.multiLingualData;
           if (!this._playlistData) {
             this._playlistData = {};
           }
@@ -44,6 +46,11 @@ export class DataManager {
           }
           if (baseEntry) {
             this._playlistData.baseEntry = baseEntry.reduce((acc, cur) => {
+              return {...acc, [cur.id]: cur};
+            }, {});
+          }
+          if (multiLingual) {
+            this._playlistData.multiLingual = multiLingual.reduce((acc, cur) => {
               return {...acc, [cur.id]: cur};
             }, {});
           }

--- a/src/providers/playlist-loader.ts
+++ b/src/providers/playlist-loader.ts
@@ -1,6 +1,8 @@
 import { RequestBuilder } from '@playkit-js/playkit-js-providers/ovp-provider';
 import {KalturaViewHistoryUserEntry, KalturaViewHistoryUserEntryListResponse, KalturaBaseEntry, KalturaBaseEntryListResponse} from './response-types';
 import {ILoader} from '@playkit-js/playkit-js-providers/types';
+import {KalturaMultiLingualResponse} from './response-types/kaltura-multi-lingual-response';
+import {KalturaMultiLingualData} from './response-types/kaltura-multi-lingual-data';
 
 interface PlaylistLoaderParams {
   playlistItems: Array<any>; // TODO take difinition from KalturaPlayerTypes.Playlist
@@ -9,6 +11,7 @@ interface PlaylistLoaderParams {
 interface PlaylistResponse {
   viewHistory: Array<KalturaViewHistoryUserEntry>;
   baseEntry: Array<KalturaBaseEntry>;
+  multiLingualData: Array<KalturaMultiLingualData>;
 }
 
 export class PlaylistLoader implements ILoader {
@@ -16,7 +19,8 @@ export class PlaylistLoader implements ILoader {
   _requests: RequestBuilder[] = [];
   _response: PlaylistResponse = {
     viewHistory: [],
-    baseEntry: []
+    baseEntry: [],
+    multiLingualData: []
   };
 
   static get id(): string {
@@ -50,7 +54,8 @@ export class PlaylistLoader implements ILoader {
       filter: {
         idIn: entryIds,
         objectType: 'KalturaMediaEntryFilter'
-      }
+      },
+      language: 'multi'
     };
     this.requests.push(baseEntryRequest);
 
@@ -70,9 +75,13 @@ export class PlaylistLoader implements ILoader {
     if (viewHistoryUserEntryListResponse.totalCount) {
       this._response.viewHistory = viewHistoryUserEntryListResponse?.data;
     }
-    const klalturaUserEntryListResponse = new KalturaBaseEntryListResponse(response[1]?.data);
-    if (klalturaUserEntryListResponse.totalCount) {
-      this._response.baseEntry = klalturaUserEntryListResponse?.data;
+    const kalturaUserEntryListResponse = new KalturaBaseEntryListResponse(response[1]?.data);
+    if (kalturaUserEntryListResponse.totalCount) {
+      this._response.baseEntry = kalturaUserEntryListResponse?.data;
+    }
+    const multiLingualResponse = new KalturaMultiLingualResponse(response[1]?.data);
+    if (multiLingualResponse.totalCount) {
+      this._response.multiLingualData = multiLingualResponse?.data;
     }
   }
 

--- a/src/providers/response-types/kaltura-multi-lingual-data.ts
+++ b/src/providers/response-types/kaltura-multi-lingual-data.ts
@@ -1,0 +1,19 @@
+export interface MultiLingualData {
+  language: string;
+  value: string;
+}
+
+export interface KalturaMultiLingualArgs {
+  id: string;
+  name: Array<MultiLingualData> | string;
+}
+
+export class KalturaMultiLingualData {
+  id: string;
+  name: Array<MultiLingualData> | string;
+
+  constructor(multiLingual: KalturaMultiLingualArgs) {
+    this.id = multiLingual.id;
+    this.name = multiLingual.name;
+  }
+}

--- a/src/providers/response-types/kaltura-multi-lingual-data.ts
+++ b/src/providers/response-types/kaltura-multi-lingual-data.ts
@@ -1,19 +1,19 @@
-export interface MultiLingualData {
+export interface MultiLingualName {
   language: string;
   value: string;
 }
 
 export interface KalturaMultiLingualArgs {
   id: string;
-  name: Array<MultiLingualData> | string;
+  name: Array<MultiLingualName> | string;
 }
 
 export class KalturaMultiLingualData {
   id: string;
-  name: Array<MultiLingualData> | string;
+  names: Array<MultiLingualName> | string;
 
   constructor(multiLingual: KalturaMultiLingualArgs) {
     this.id = multiLingual.id;
-    this.name = multiLingual.name;
+    this.names = multiLingual.name;
   }
 }

--- a/src/providers/response-types/kaltura-multi-lingual-response.ts
+++ b/src/providers/response-types/kaltura-multi-lingual-response.ts
@@ -1,0 +1,18 @@
+import {KalturaMultiLingualArgs, KalturaMultiLingualData} from './kaltura-multi-lingual-data';
+const {BaseServiceResult} = KalturaPlayer.providers.ResponseTypes;
+
+export class KalturaMultiLingualResponse extends BaseServiceResult {
+  totalCount?: number;
+  data: Array<KalturaMultiLingualData> = [];
+
+  constructor(responseObj: any) {
+    super(responseObj);
+    if (!this.hasError) {
+      this.totalCount = responseObj.totalCount;
+      if (this.totalCount! > 0) {
+        this.data = [];
+        responseObj.objects.map((ml: KalturaMultiLingualArgs) => this.data.push(new KalturaMultiLingualData(ml)));
+      }
+    }
+  }
+}

--- a/src/types/types-ui.ts
+++ b/src/types/types-ui.ts
@@ -1,4 +1,5 @@
 import {KalturaViewHistoryUserEntry, KalturaBaseEntry} from '../providers';
+import {KalturaMultiLingualData} from '../providers/response-types/kaltura-multi-lingual-data';
 
 export type OnClick = (e: KeyboardEvent | MouseEvent, byKeyboard?: boolean) => void;
 
@@ -15,4 +16,5 @@ export enum PluginStates {
 export interface PlaylistExtraData {
   viewHistory?: Record<string, KalturaViewHistoryUserEntry>;
   baseEntry?: Record<string, KalturaBaseEntry>;
+  multiLingual?: Record<string, KalturaMultiLingualData>;
 }


### PR DESCRIPTION
**Requirement:**
render the title of a playlist item based on the multilingual object.

**Changes:**
- add a request for multilingual to the multi-request in `playlist-loader` and parse the response
- add the `multiLingualData` to `playlistExtraData` data structure
- pass `locale` and `multiLingual` to `playlistItem` component
- calculate the `playlistItemName` based on the `multilingual` and `locale` information; fallback to original value (`metadata.name`)

Resolved [FEC-14489](https://kaltura.atlassian.net/browse/FEC-14489)

[FEC-14489]: https://kaltura.atlassian.net/browse/FEC-14489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ